### PR TITLE
Connect Web Socket with IPv6.

### DIFF
--- a/src/interface/IWebsocketClientLite.Netstandard/IMessageWebSocketRx.cs
+++ b/src/interface/IWebsocketClientLite.Netstandard/IMessageWebSocketRx.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net.Security;
+using System.Net.Sockets;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -32,7 +33,8 @@ namespace IWebsocketClientLite.PCL
 
         Task ConnectAsync(
             Uri uri,
-            TimeSpan timeout = default);
+            TimeSpan timeout = default,
+            AddressFamily addressFamily = AddressFamily.InterNetwork);
 
         Task DisconnectAsync();
 

--- a/src/interface/IWebsocketClientLite.Netstandard/IMessageWebSocketRx.cs
+++ b/src/interface/IWebsocketClientLite.Netstandard/IMessageWebSocketRx.cs
@@ -33,8 +33,7 @@ namespace IWebsocketClientLite.PCL
 
         Task ConnectAsync(
             Uri uri,
-            TimeSpan timeout = default,
-            AddressFamily addressFamily = AddressFamily.InterNetwork);
+            TimeSpan timeout = default);
 
         Task DisconnectAsync();
 

--- a/src/interface/IWebsocketClientLite.Netstandard/IMessageWebSocketRx.cs
+++ b/src/interface/IWebsocketClientLite.Netstandard/IMessageWebSocketRx.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net.Security;
-using System.Net.Sockets;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;

--- a/src/main/WebsocketClientLite.Netstandard20/MessageWebSocketRx.cs
+++ b/src/main/WebsocketClientLite.Netstandard20/MessageWebSocketRx.cs
@@ -83,12 +83,11 @@ namespace WebsocketClientLite.PCL
        
         public async Task ConnectAsync(
             Uri uri,
-            TimeSpan timeout = default,
-            AddressFamily addressFamily = AddressFamily.InterNetwork)
+            TimeSpan timeout = default)
         {
             _observerConnectionStatus.OnNext(ConnectionStatus.ConnectingToTcpSocket);
             
-            await ConnectTcpClient(uri, timeout, addressFamily);
+            await ConnectTcpClient(uri, timeout);
 
             _tcpStream = await DetermineStreamTypeAsync(uri, _tcpClient, X509CertCollection, TlsProtocolType);
 
@@ -195,12 +194,12 @@ namespace WebsocketClientLite.PCL
             return tcpClient.GetStream();
         }
 
-        private async Task ConnectTcpClient(Uri uri, TimeSpan timeout = default, AddressFamily addressFamily = AddressFamily.InterNetwork)
+        private async Task ConnectTcpClient(Uri uri, TimeSpan timeout = default)
         {
             if (!_isTcpClientProvided)
             {
                 _tcpClient?.Dispose();
-                _tcpClient = new TcpClient(addressFamily);
+                _tcpClient = new TcpClient(uri.HostNameType == UriHostNameType.IPv6 ? AddressFamily.InterNetworkV6 : AddressFamily.InterNetwork);
             }
             else
             {

--- a/src/main/WebsocketClientLite.Netstandard20/MessageWebSocketRx.cs
+++ b/src/main/WebsocketClientLite.Netstandard20/MessageWebSocketRx.cs
@@ -83,11 +83,12 @@ namespace WebsocketClientLite.PCL
        
         public async Task ConnectAsync(
             Uri uri,
-            TimeSpan timeout = default)
+            TimeSpan timeout = default,
+            AddressFamily addressFamily = AddressFamily.InterNetwork)
         {
             _observerConnectionStatus.OnNext(ConnectionStatus.ConnectingToTcpSocket);
             
-            await ConnectTcpClient(uri, timeout);
+            await ConnectTcpClient(uri, timeout, addressFamily);
 
             _tcpStream = await DetermineStreamTypeAsync(uri, _tcpClient, X509CertCollection, TlsProtocolType);
 
@@ -194,12 +195,12 @@ namespace WebsocketClientLite.PCL
             return tcpClient.GetStream();
         }
 
-        private async Task ConnectTcpClient(Uri uri, TimeSpan timeout = default)
+        private async Task ConnectTcpClient(Uri uri, TimeSpan timeout = default, AddressFamily addressFamily = AddressFamily.InterNetwork)
         {
             if (!_isTcpClientProvided)
             {
                 _tcpClient?.Dispose();
-                _tcpClient = new TcpClient();
+                _tcpClient = new TcpClient(addressFamily);
             }
             else
             {


### PR DESCRIPTION
Connecting to IPv4 address would work normally. Whereas while trying to connect to a Web Socket host with IPv6 the package would throw "TCP Socket connection timed-out to `IPv6 address`:`Port`." or "Unable to establish TCP Socket connection to: `IPv6 address`:`Port`"

Now ConnectAsync will take an optional pameter `AddressFamily` helping TcpClinet to connect to the host smoothly. 