### PR TITLE
Feature/Multi-Targetting

### DIFF
--- a/src/build/WebsocketClientLite.PCL.nuspec
+++ b/src/build/WebsocketClientLite.PCL.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>WebsocketClientLite.PCL</id>
     <version>0</version>
-    <title>Websocket Client Lite (.NET Standard 2.1)</title>
+    <title>Websocket Client Lite (.NET Standard 2.0 and 2.1)</title>
     <authors>1iveowl Developement</authors>
     <owners>Jasper H. Bojsen</owners>
     <license type="expression">MIT</license>
@@ -22,9 +22,16 @@ Observe incoming message using Reactive Extensions (Rx)</description>
     
     <dependencies>
 
-      <group targetFramework="netstandard2.1">
+      <group targetFramework="netstandard2.0">
+        <dependency id="HttpMachine.PCL" version="4.0.2"/>
+        <dependency id="Microsoft.Bcl.AsyncInterfaces" version="6.0.0" />
+        <dependency id="System.Memory" version="4.5.4" />
         <dependency id="System.Reactive" version="5.0.0"/>
-        <dependency id="HttpMachine.PCL" version="4.0.2"/>	  
+      </group>
+
+      <group targetFramework="netstandard2.1">
+        <dependency id="HttpMachine.PCL" version="4.0.2"/>
+        <dependency id="System.Reactive" version="5.0.0"/>
 	  </group>
       
     </dependencies>

--- a/src/main/WebsocketClientLite.Netstandard20/Helper/DataframeParsing.cs
+++ b/src/main/WebsocketClientLite.Netstandard20/Helper/DataframeParsing.cs
@@ -146,7 +146,12 @@ namespace WebsocketClientLite.PCL.Helper
             {
                 var memoryStream = new MemoryStream();
 
-                await memoryStream.WriteAsync(await dataframe.GetNextBytes(dataframe.Length));
+                var nextBytes = await dataframe.GetNextBytes(dataframe.Length);
+#if NETSTANDARD2_1
+                await memoryStream.WriteAsync(nextBytes);
+#else
+                await memoryStream.WriteAsync(nextBytes, 0, nextBytes.Length);
+#endif
 
                 if (dataframe.MASK)
                 {

--- a/src/main/WebsocketClientLite.Netstandard20/Service/WebsocketParserHandler.cs
+++ b/src/main/WebsocketClientLite.Netstandard20/Service/WebsocketParserHandler.cs
@@ -55,7 +55,12 @@ namespace WebsocketClientLite.PCL.Service
 
                     if (nextDataframe is not null)
                     {
-                        await nextDataframe.DataStream.CopyToAsync(dataframe.DataStream, cts.Token);
+                        await nextDataframe.DataStream.CopyToAsync(dataframe.DataStream,
+#if !NETSTANDARD2_1
+                            81920,
+#endif
+                            cts.Token);
+
 
                         dataframe = dataframe with
                         {

--- a/src/main/WebsocketClientLite.Netstandard20/WebsocketClientLite.Netstandard20.csproj
+++ b/src/main/WebsocketClientLite.Netstandard20/WebsocketClientLite.Netstandard20.csproj
@@ -9,9 +9,12 @@
 
   <ItemGroup>
     <PackageReference Include="HttpMachine.PCL" Version="4.0.2" />
+    <PackageReference Include="System.Reactive" Version="5.0.0" />
+  </ItemGroup>
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
-    <PackageReference Include="System.Reactive" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/main/WebsocketClientLite.Netstandard20/WebsocketClientLite.Netstandard20.csproj
+++ b/src/main/WebsocketClientLite.Netstandard20/WebsocketClientLite.Netstandard20.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <AssemblyName>WebsocketClientLite.PCL</AssemblyName>
     <RootNamespace>WebsocketClientLite.PCL</RootNamespace>
     <LangVersion>10.0</LangVersion>
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="HttpMachine.PCL" Version="4.0.2" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Reactive" Version="5.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
As a follow-up on issue #67 in which the TFM was corrected in the nuspec file to netstandard2.1, making me unable to consume the package.
This PR basically re-adds support for netstandard2.0 again by taking an additional dependency on `Microsoft.Bcl.AsyncInterfaces` (for the `IAsyncEnumerable<T>` type) and `System.Memory` (for Span<T> and Memory<T> types/support)
Furthermore does it fix 2 method calls for which the exact signature is available in netstandard2.1, but not in netstandard2.0.

If there's something missing or anything, feel free to let me know.

(Targets the master branch due to this containing the latest changes)