### PR TITLE
Three Fixes

### DIFF
--- a/src/main/WebsocketClientLite/Factory/WebsocketServiceFactory.cs
+++ b/src/main/WebsocketClientLite/Factory/WebsocketServiceFactory.cs
@@ -25,6 +25,7 @@ namespace WebsocketClientLite.PCL.Factory
             IObserver<ConnectionStatus> observerConnectionStatus,
             MessageWebsocketRx messageWebSocketRx)
         {
+            var sendSem = new SemaphoreSlim(1, 1);
 
             var tcpConnectionHandler = new TcpConnectionService(
                 isSecureConnectionSchemeFunc: isSecureConnectionSchemeFunc,
@@ -51,8 +52,8 @@ namespace WebsocketClientLite.PCL.Factory
                                 messageWebSocketRx.ExcludeZeroApplicationDataInPong
                             )
                         )                        
-                );            
-
+                );
+            
             await Task.CompletedTask;
 
             return websocketServices;
@@ -74,7 +75,16 @@ namespace WebsocketClientLite.PCL.Factory
 
             async Task<bool> WriteToStream(Stream stream, byte[] byteArray, CancellationToken ct)
             {
-                await stream.WriteAsync(byteArray, 0, byteArray.Length, ct).ConfigureAwait(false);
+                try
+                {
+                    await sendSem.WaitAsync(ct);
+                    await stream.WriteAsync(byteArray, 0, byteArray.Length, ct).ConfigureAwait(false);
+                }
+                finally
+                {
+                    sendSem.Release();
+                }
+                
                 await stream.FlushAsync().ConfigureAwait(false);
 
                 return true;

--- a/src/main/WebsocketClientLite/MessageWebSocketRx.cs
+++ b/src/main/WebsocketClientLite/MessageWebSocketRx.cs
@@ -154,6 +154,7 @@ namespace WebsocketClientLite.PCL
                                 this))
                             .Select(ws => Observable.FromAsync(ct => ConnectWebsocket(ws, ct))
                                 .Concat()
+                                .Finally(() => ws.Dispose())
                                 .Subscribe(
                                     dataframe => { obsTuple.OnNext((dataframe, ConnectionStatus.DataframeReceived)); },
                                     ex => { obsTuple.OnError(ex); },

--- a/src/main/WebsocketClientLite/Service/WebsocketSenderHandler.cs
+++ b/src/main/WebsocketClientLite/Service/WebsocketSenderHandler.cs
@@ -130,7 +130,7 @@ namespace WebsocketClientLite.PCL.Service
             Dataframe dataframe,
             CancellationToken ct) => 
                 await ComposeFrameAndSendAsync(
-                    dataframe.Binary,
+                    dataframe.Binary ?? new Byte[0],
                     OpcodeKind.Pong,
                     FragmentKind.None,
                     ct);
@@ -200,7 +200,7 @@ namespace WebsocketClientLite.PCL.Service
         {
             var frame = new byte[1] { DetermineFINBit(opcode, fragment) };
 
-            if (content is not null)
+            if (content is not null || (opcode == OpcodeKind.Pong && content is not null))
             {
                 var maskKey = CreateMaskKey();
                 frame = frame.Concat(CreatePayloadBytes(content.Length, isMasking: true))
@@ -212,7 +212,7 @@ namespace WebsocketClientLite.PCL.Service
             {
                 frame = frame
                     .Concat(new byte[1] { 0 })
-                    .ToArray();                
+                    .ToArray();
             }
 
             await SendFrameAsync(


### PR DESCRIPTION
A) (important) - ClientPing is not disposed on connection close, leading to pings to nowhere. Maybe I found the right place to trigger the disposal, maybe not ;-)

B) (important) I had issues with all my WebSocket use cases, as my replies to server pings were not accepted. See my working solution, which clearly should not be taken over as-is.

C) (optional) During debugging I got exceptions for concurrent write accesses. so I protected it with a semaphore. Not sure if relevant in practice, but might make sense to integrate.