### PR TITLE
Minor fixes and build note

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,9 @@ This library was developed using the following reference documentation:
 
 ## Building and Contributing
 
-This library targets .NET Standard 2.0, .NET Standard 2.1, .NET 6, .NET 8, and .NET 9. The CI/CD pipeline uses GitHub Actions to build, test, and publish packages to NuGet and GitHub Packages.
+This library targets .NET Standard 2.0, .NET Standard 2.1, .NET 6, .NET 8, and .NET 9. The CI/CD pipeline uses GitHub Actions to build, test, and publish packages.
+
+To build locally you need the matching .NET SDKs installed. Some projects target .NET 9.0 which currently requires the preview .NET 9 SDK. If the SDK is not available only the .NET 8 and lower projects can be built.
 
 For contributors and developers, please ensure your changes maintain compatibility with these target frameworks.
 

--- a/src/main/WebsocketClientLite/Helper/WebsocketMasking.cs
+++ b/src/main/WebsocketClientLite/Helper/WebsocketMasking.cs
@@ -8,7 +8,7 @@ namespace WebsocketClientLite.Helper;
 internal static class WebsocketMasking
 {
 #pragma warning disable IDE1006 // Naming Styles
-    private const byte FINbit = 0x80;
+    private const byte MaskBit = 0x80;
 #pragma warning restore IDE1006 // Naming Styles
 
     internal static byte[] Encode(IReadOnlyList<byte> data, IReadOnlyList<byte> key)
@@ -48,16 +48,16 @@ internal static class WebsocketMasking
         {
             if (isMasking)
             {
-                firstPayloadByte = (byte)(length + FINbit);
+                firstPayloadByte = (byte)(length + MaskBit);
             }
             return [firstPayloadByte];
         }
 
-        if (length >= (byte)PayloadBitLengthKind.Bits16 && length <= Math.Pow(2, 16))
+        if (length >= (byte)PayloadBitLengthKind.Bits16 && length <= ushort.MaxValue)
         {
             if (isMasking)
             {
-                firstPayloadByte = (byte)PayloadBitLengthKind.Bits16 + FINbit;
+                firstPayloadByte = (byte)PayloadBitLengthKind.Bits16 + MaskBit;
             }
 
             var payloadLength = BitConverter.GetBytes((ushort)length);
@@ -73,11 +73,11 @@ internal static class WebsocketMasking
             return byteArray;
         }
 
-        if (length >= Math.Pow(2, 16) && length <= Math.Pow(2, 64))
+        if (length > ushort.MaxValue && length <= int.MaxValue)
         {
             if (isMasking)
             {
-                firstPayloadByte = (byte)PayloadBitLengthKind.Bits64 + FINbit;
+                firstPayloadByte = (byte)PayloadBitLengthKind.Bits64 + MaskBit;
             }
 
             var payloadLength = BitConverter.GetBytes((ulong)length);


### PR DESCRIPTION
## Summary
- fix payload length validation in `WebsocketMasking`
- document SDK requirements for building

## Testing
- `dotnet test src/main/WebsocketClientLiteTest/WebsocketClientLiteTest.csproj -v minimal` *(fails: NETSDK1045)*
- `dotnet build src/main/WebsocketClientLite.sln --no-restore -c Release` *(fails: NETSDK1045)*


------
https://chatgpt.com/codex/tasks/task_e_686e7ee5aa40832bb1ddf940a5bd2893