### PR TITLE
v9.0.1: post-release review fixes (close-on-unsubscribe, fail-fast handshake, throwing sends, packaging)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,37 +100,33 @@ jobs:
           tag_name: ${{ steps.gitversion.outputs.AssemblySemVer }}
           release_name: Release ${{ steps.gitversion.outputs.AssemblySemVer }}
           body: |
-            WebsocketClientLite 9.0.0 – Highlights
+            WebsocketClientLite 9.0.1 – Highlights
 
             Bug fixes
-            - Subprotocols are now actually sent in the handshake (Sec-WebSocket-Protocol).
-            - Close status codes are sent big-endian per RFC 6455.
-            - ExcludeZeroApplicationDataInPong is now honored (Slack RTM).
-            - The CancellationToken passed to WebsocketConnectObservable is forwarded.
-            - Fragmented messages reassemble correctly on .NET 8/9/10 and .NET Standard 2.1.
-            - Writes to the connection are serialized, fixing mid-stream disconnects when
-              client pings interleave with sends.
+            - Unsubscribing from the connection observable now sends the RFC 6455 close
+              handshake (best-effort, exactly once) instead of just dropping the TCP
+              connection.
+            - A failed handshake (e.g. HTTP 404) now fails fast with the server's status
+              code instead of reporting an internal success state and waiting out the
+              handshake timeout.
+            - Send failures now throw WebsocketClientLiteException at the await site, in
+              addition to reporting SendError on the status channel.
+            - The final Disconnected status is delivered (Rx-grammar fix in the status
+              callbacks).
+            - A Close frame received mid-fragmentation cleanly aborts the message and the
+              read loop no longer runs into EOF after a close.
+            - Disposing the client while a connection is active no longer throws from
+              teardown.
+            - NuGet packaging: the interface assembly is no longer bundled into
+              lib/netstandard2.0/2.1 alongside the IWebsocketClientLite dependency.
 
-            Security hardening
-            - Configurable MaxFrameSize (default 16 MiB) caps incoming frames and reassembled
-              messages to guard against memory-exhaustion from a malicious server.
-            - Control frames are validated (<=125 bytes, not fragmented) per RFC 6455 §5.5.
-            - Handshake header/origin/subprotocol values containing CR/LF/NUL are rejected.
-            - CheckCertificateRevocation option (default true) enables TLS revocation checking.
+            New
+            - ClientWebSocketRx.NegotiatedSubprotocols exposes the subprotocol(s) the
+              server accepted during the handshake.
 
-            Performance
-            - Receive path reads each payload once and unmasks in place (no MemoryStream,
-              far fewer allocations); frames are read from a single subscription.
-            - Send path avoids per-frame mask-key and text-encoding allocations.
-
-            Breaking changes
-            - ClientWebSocketRx is now a class instead of a record, and its TcpClient
-              property is nullable.
-            - CheckCertificateRevocation defaults to true; set it to false if your
-              environment cannot reach OCSP/CRL endpoints.
-
-            Tooling
-            - Tests run against every target framework (netstandard2.0..net10) and a CI
-              workflow builds, tests, and gates code coverage.
+            Notes
+            - A user-supplied TcpClient can only serve the first connection; leave
+              TcpClient unset when using reconnect patterns (Retry/Repeat). The console
+              sample and README have been updated accordingly.
           draft: true
           prerelease: true

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,4 @@
-next-version: 9.0.0
+next-version: 9.0.1
 branches: {}
 ignore:
   sha: []

--- a/README.md
+++ b/README.md
@@ -26,6 +26,24 @@ The library provides developers with additional flexibility, including the abili
 
 The library utilizes [ReactiveX](http://reactivex.io/) (aka Rx or Reactive Extensions). While this dependency introduces a small learning curve, it's worthwhile for the context.
 
+## New in Version 9.0.1
+
+Version 9.0.1 is a correctness and robustness patch on top of 9.0.
+
+**Bug fixes**
+
+- **Unsubscribing now sends a close handshake.** Disposing the connection subscription previously dropped the TCP connection without an RFC 6455 close frame; the close is now sent best-effort on every teardown path, exactly once.
+- **Failed handshakes fail fast.** A non-101 response (e.g. 404) now surfaces immediately as an error carrying the server's status code, instead of reporting a misleading internal "success" state and waiting out the handshake timeout.
+- **Send failures throw.** `await sender.SendText(...)` (and all other sends) now throws `WebsocketClientLiteException` when the write fails, in addition to reporting `SendError` on the status channel. Previously failures were silent at the call site.
+- **The final `Disconnected` status is delivered.** An Rx-grammar bug completed the status stream before emitting the last status.
+- **NuGet packaging:** the interface assembly is no longer bundled into `lib/netstandard2.0/2.1` alongside the `IWebsocketClientLite` package dependency (which could cause duplicate-assembly/type-conflict issues).
+- **Reconnect guidance:** supplying your own `TcpClient` only works for the first connection; the sample and docs now reflect that reconnect patterns require leaving `TcpClient` unset. See the note under *Creating a WebSocket Client*.
+- Disposing the client while a connection is active no longer throws from teardown; a `Close` received mid-fragmentation now cleanly aborts the message; per-frame header reads no longer allocate.
+
+**New**
+
+- **`NegotiatedSubprotocols`** on `ClientWebSocketRx` exposes the subprotocol(s) the server accepted during the handshake.
+
 ## New in Version 9.0
 
 Version 9.0 is a correctness and protocol-compliance release.
@@ -135,6 +153,7 @@ var client = new ClientWebSocketRx { TcpClient = tcpClient, HasTransferSocketLif
 >
 > - If the TcpClient is not connected already the library will connect it. 
 > - The TcpClient will not be disposed automatically when passed in using the constructor unless `HasTransferSocketLifeCycleOwnership = true` is set.
+> - **A supplied `TcpClient` can only serve one connection.** Its socket is closed when the connection tears down, and .NET sockets cannot be reconnected. If you use reconnect patterns such as `Retry()`/`Repeat()`, leave `TcpClient` unset so every attempt gets a fresh socket.
 
 ### Connecting to a WebSocket Server
 

--- a/src/interface/IWebsocketClientLite/IWebsocketClientLite.csproj
+++ b/src/interface/IWebsocketClientLite/IWebsocketClientLite.csproj
@@ -8,13 +8,13 @@
 	<LangVersion>14.0</LangVersion>
 	<PackageIcon>images\1iveowl-logo.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>9.0.0</Version>
+    <Version>9.0.1</Version>
     <Authors>Jasper Hedegaard Bojsen</Authors>
     <Copyright>1iveowl Development 2025</Copyright>
     <PackageProjectUrl>https://github.com/1iveowl/IWebsocketClientLite.PCL</PackageProjectUrl>
     <RepositoryUrl>https://github.com/1iveowl/WebsocketClientLite.PCL</RepositoryUrl>
-    <AssemblyVersion>9.0.0</AssemblyVersion>
-    <FileVersion>9.0.0</FileVersion>
+    <AssemblyVersion>9.0.1</AssemblyVersion>
+    <FileVersion>9.0.1</FileVersion>
     <Description>Interface for WebSocket Client Lite.</Description>
   </PropertyGroup>
 

--- a/src/main/WebsocketClientLite/ClientWebSocketRx.cs
+++ b/src/main/WebsocketClientLite/ClientWebSocketRx.cs
@@ -72,6 +72,14 @@ public class ClientWebSocketRx : IWebSocketClientRx, IDisposable
     public IEnumerable<string>? Subprotocols { get; init; }
 
     /// <summary>
+    /// The subprotocols the server accepted during the most recent successful
+    /// handshake (the intersection with <see cref="Subprotocols"/>), or
+    /// <see langword="null"/> when none were negotiated or no connection has
+    /// been established yet.
+    /// </summary>
+    public IEnumerable<string>? NegotiatedSubprotocols { get; private set; }
+
+    /// <summary>
     /// TLS protocol
     /// </summary>
     public SslProtocols TlsProtocolType { get; init; } = SslProtocols.None;
@@ -216,9 +224,10 @@ public class ClientWebSocketRx : IWebSocketClientRx, IDisposable
             handshaketimeout = TimeSpan.FromSeconds(30);
         }
 
-        void initSender(ISender sender)
+        void initSender(ISender sender, IEnumerable<string>? negotiatedSubprotocols)
         {
             Sender = sender;
+            NegotiatedSubprotocols = negotiatedSubprotocols;
             SetIsConnected(true);
         }
 

--- a/src/main/WebsocketClientLite/ClientWebSocketRx.cs
+++ b/src/main/WebsocketClientLite/ClientWebSocketRx.cs
@@ -114,6 +114,22 @@ public class ClientWebSocketRx : IWebSocketClientRx, IDisposable
         _disposables.Add(connectedBehavior);
     }
 
+    // Connection teardown (an Rx Finally) reports IsConnected=false; if the
+    // client was disposed first the BehaviorSubject is already disposed and
+    // OnNext would throw ObjectDisposedException from inside the Finally action,
+    // crashing teardown. Swallow exactly that race.
+    private void SetIsConnected(bool isConnected)
+    {
+        try
+        {
+            _observerIsConnected.OnNext(isConnected);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Client disposed while a connection was still winding down.
+        }
+    }
+
 
     /// <summary>
     /// Is using a secure connection scheme. Override for anything but default behavior.
@@ -203,7 +219,7 @@ public class ClientWebSocketRx : IWebSocketClientRx, IDisposable
         void initSender(ISender sender)
         {
             Sender = sender;
-            _observerIsConnected.OnNext(true);
+            SetIsConnected(true);
         }
 
         return Observable.Create<(IDataframe? dataframe, ConnectionStatus state)>(obsTuple =>
@@ -224,7 +240,7 @@ public class ClientWebSocketRx : IWebSocketClientRx, IDisposable
                                 ex => { obsTuple.OnError(ex); },
                                 () => { obsTuple.OnCompleted(); }));
             })
-            .Finally(() => _observerIsConnected.OnNext(false))
+            .Finally(() => SetIsConnected(false))
             .Subscribe(
                 state => { obsTuple.OnNext((null, state)); },
                 ex => { obsTuple.OnError(ex); },

--- a/src/main/WebsocketClientLite/ClientWebSocketRx.cs
+++ b/src/main/WebsocketClientLite/ClientWebSocketRx.cs
@@ -39,9 +39,15 @@ public class ClientWebSocketRx : IWebSocketClientRx, IDisposable
     public int MaxFrameSize { get; init; } = DefaultMaxFrameSizeBytes;
 
     /// <summary>
-    /// Optional TCP client. When left null, a <see cref="TcpClient"/> is created
-    /// internally with the address family matching the target URI and is disposed
-    /// together with the connection. Supplying one avoids allocating a throwaway.
+    /// Optional TCP client. When left null (recommended), a <see cref="TcpClient"/>
+    /// is created internally with the address family matching the target URI and is
+    /// disposed together with the connection.
+    /// <para>
+    /// Important: a supplied client can only serve the FIRST connection. Its socket
+    /// is closed when the connection tears down and .NET sockets cannot be
+    /// reconnected, so reconnect patterns (e.g. <c>Retry()</c>/<c>Repeat()</c>)
+    /// require leaving this null so each attempt gets a fresh socket.
+    /// </para>
     /// </summary>
     public TcpClient? TcpClient { get; init; }
 

--- a/src/main/WebsocketClientLite/Factory/WebsocketClientFactory.cs
+++ b/src/main/WebsocketClientLite/Factory/WebsocketClientFactory.cs
@@ -53,17 +53,22 @@ internal static class WebsocketClientFactory
 
         void ConnectionStatusAction(ConnectionStatus status, Exception? ex)
         {
-            if (status is ConnectionStatus.Disconnected)
-            {
-                observerConnectionStatus.OnCompleted();
-            }
-
+            // Terminal Rx events must come last: emit the status first, then
+            // complete/error. The previous order completed before OnNext, so the
+            // final Disconnected status was silently dropped.
             if (status is ConnectionStatus.Aborted)
             {
                 observerConnectionStatus.OnError(
                     ex ?? new WebsocketClientLiteException("Unknown error."));
+                return;
             }
+
             observerConnectionStatus.OnNext(status);
+
+            if (status is ConnectionStatus.Disconnected)
+            {
+                observerConnectionStatus.OnCompleted();
+            }
         }
 
         async Task<bool> WriteToStream(Stream stream, byte[] byteArray, int count, CancellationToken ct)

--- a/src/main/WebsocketClientLite/Factory/WebsocketServiceFactory.cs
+++ b/src/main/WebsocketClientLite/Factory/WebsocketServiceFactory.cs
@@ -60,18 +60,21 @@ internal static class WebsocketServiceFactory
 
         void ConnectionStatusAction(ConnectionStatus status, Exception? ex)
         {
-            if (status is ConnectionStatus.Disconnected)
-            {
-                observerConnectionStatus.OnCompleted();
-            }
-
+            // Terminal Rx events must come last: emit the status first, then
+            // complete/error (mirrors WebsocketClientFactory).
             if (status is ConnectionStatus.Aborted)
             {
                 observerConnectionStatus.OnError(
                     ex ?? new WebsocketClientLiteException("Unknown error."));
+                return;
             }
 
             observerConnectionStatus.OnNext(status);
+
+            if (status is ConnectionStatus.Disconnected)
+            {
+                observerConnectionStatus.OnCompleted();
+            }
         }
 
         async Task<bool> WriteToStream(Stream stream, byte[] byteArray, int count, CancellationToken ct)

--- a/src/main/WebsocketClientLite/Helper/DataframeParsing.cs
+++ b/src/main/WebsocketClientLite/Helper/DataframeParsing.cs
@@ -20,7 +20,7 @@ internal static class DataframeParsing
         this TcpConnectionService tcpConnection,
         CancellationToken ct)
     {
-        var header = await tcpConnection.ReadBytesFromStream(2, ct).ConfigureAwait(false);
+        var header = await tcpConnection.ReadHeaderBytesAsync(2, ct).ConfigureAwait(false);
         if (header is null)
         {
             return null;
@@ -45,7 +45,7 @@ internal static class DataframeParsing
         }
         else if (lengthMarker == 126)
         {
-            var ext = await tcpConnection.ReadBytesFromStream(2, ct).ConfigureAwait(false);
+            var ext = await tcpConnection.ReadHeaderBytesAsync(2, ct).ConfigureAwait(false);
             if (ext is null)
             {
                 return null;
@@ -54,7 +54,7 @@ internal static class DataframeParsing
         }
         else
         {
-            var ext = await tcpConnection.ReadBytesFromStream(8, ct).ConfigureAwait(false);
+            var ext = await tcpConnection.ReadHeaderBytesAsync(8, ct).ConfigureAwait(false);
             if (ext is null)
             {
                 return null;
@@ -97,7 +97,9 @@ internal static class DataframeParsing
         if (mask)
         {
             // For masked frames the masking key precedes the payload per RFC 6455.
-            maskKey = await tcpConnection.ReadBytesFromStream(4, ct).ConfigureAwait(false);
+            // The scratch buffer stays valid through the payload read below (which
+            // fills its own array) and is consumed by Decode before the next read.
+            maskKey = await tcpConnection.ReadHeaderBytesAsync(4, ct).ConfigureAwait(false);
             if (maskKey is null)
             {
                 return null;

--- a/src/main/WebsocketClientLite/MessageWebSocketRx.cs
+++ b/src/main/WebsocketClientLite/MessageWebSocketRx.cs
@@ -187,7 +187,7 @@ public class MessageWebsocketRx(
                                                 Headers,
                                                 Subprotocols).ConfigureAwait(false);
 
-        void InitializeSender(ISender sender)
+        void InitializeSender(ISender sender, IEnumerable<string>? negotiatedSubprotocols)
         {
             _sender = sender;
             IsConnected = true;

--- a/src/main/WebsocketClientLite/Model/Dataframe.cs
+++ b/src/main/WebsocketClientLite/Model/Dataframe.cs
@@ -5,8 +5,6 @@ namespace WebsocketClientLite.Model;
 
 internal record Dataframe : IDataframe
 {
-    private string? _message;
-
     internal bool FIN { get; init; }
     internal bool RSV1 { get; init; }
     internal bool RSV2 { get; init; }
@@ -23,15 +21,11 @@ internal record Dataframe : IDataframe
 
     public byte[]? Binary => Payload;
 
-    public string? Message => GetMessage();
-
-    private string? GetMessage()
-    {
-        if (_message is null && Payload is not null && Opcode is OpcodeKind.Text)
-        {
-            _message = Encoding.UTF8.GetString(Payload, 0, Payload.Length);
-        }
-
-        return _message;
-    }
+    // Computed on demand rather than cached in a field: a cached value would be
+    // carried along by `with` clones (e.g. fragment reassembly replacing Payload)
+    // and could go stale relative to the new payload.
+    public string? Message =>
+        Payload is not null && Opcode is OpcodeKind.Text
+            ? Encoding.UTF8.GetString(Payload, 0, Payload.Length)
+            : null;
 }

--- a/src/main/WebsocketClientLite/Parser/HandshakeParser.cs
+++ b/src/main/WebsocketClientLite/Parser/HandshakeParser.cs
@@ -61,16 +61,17 @@ internal class HandshakeParser(
                     }
                 }
 
-                Debug.WriteLine("HandShake completed");            
+                Debug.WriteLine("HandShake completed");
                 return true;
             }
             else
             {
-                _connectionStatusAction(
-                    ConnectionStatus.Aborted,
-                    new WebsocketClientLiteException($"Unable to connect to websocket Server. " +
-                                    $"Error code: {_parserDelegate.HttpRequestResponse.StatusCode}, " +
-                                    $"Error reason: {_parserDelegate.HttpRequestResponse.ResponseReason}"));
+                // Non-101 response: the HTTP message is complete, so parsing is
+                // done. The failure itself is reported by HandshakeParserDelegate
+                // (HandshakeFailed + exception), which the connect path awaits —
+                // no side-channel Abort needed, and no further bytes to read.
+                Debug.WriteLine($"Handshake rejected: {_parserDelegate.HttpRequestResponse.StatusCode}");
+                return true;
             }
         }
 

--- a/src/main/WebsocketClientLite/Parser/HandshakeParser.cs
+++ b/src/main/WebsocketClientLite/Parser/HandshakeParser.cs
@@ -43,7 +43,11 @@ internal class HandshakeParser(
                         .Headers
                         .TryGetValue("SEC-WEBSOCKET-PROTOCOL", out var subprotocolAcceptedNames))
                     {
-                        SubprotocolAcceptedNames = subprotocolAcceptedNames.Where(spn => subProtocols.Contains(spn));
+                        // Materialize: evaluated once, and consumers (the public
+                        // NegotiatedSubprotocols property) get a stable snapshot.
+                        SubprotocolAcceptedNames = subprotocolAcceptedNames
+                            .Where(spn => subProtocols.Contains(spn))
+                            .ToList();
 
                         if (!SubprotocolAcceptedNames?.Any() ?? true)
                         {

--- a/src/main/WebsocketClientLite/Parser/HandshakeParserDelegate.cs
+++ b/src/main/WebsocketClientLite/Parser/HandshakeParserDelegate.cs
@@ -1,4 +1,4 @@
-﻿using HttpMachine;
+using HttpMachine;
 using IHttpMachine;
 using System;
 using WebsocketClientLite.CustomException;
@@ -25,17 +25,31 @@ internal class HandshakeParserDelegate(
     {
         base.OnMessageEnd(combinedParser);
 
-        if (HttpRequestResponse.IsEndOfMessage)
+        if (!HttpRequestResponse.IsEndOfMessage)
+        {
+            // Defensive: should not happen — OnMessageEnd implies a complete message.
+            observerHandshakeParserState
+                .OnNext((HandshakeStateKind.HandshakeFailed, null));
+            observerHandshakeParserState.OnError(new WebsocketClientLiteException("Unable to complete handshake"));
+            return;
+        }
+
+        // Only "101 Switching Protocols" is a successful WebSocket upgrade. Any
+        // other complete response is a failed handshake — report it as such so
+        // the connect path can fail fast with the server's status line.
+        if (HttpRequestResponse.StatusCode == 101)
         {
             observerHandshakeParserState
                 .OnNext((HandshakeStateKind.HandshakeCompletedSuccessfully, null));
         }
         else
         {
-            observerHandshakeParserState
-                .OnNext((HandshakeStateKind.HandshakeFailed, null));
-            observerHandshakeParserState.OnError(new WebsocketClientLiteException("Unable to complete handshake"));
-            return;
+            observerHandshakeParserState.OnNext((
+                HandshakeStateKind.HandshakeFailed,
+                new WebsocketClientLiteException(
+                    $"Unable to connect to websocket server. " +
+                    $"HTTP status: {HttpRequestResponse.StatusCode}, " +
+                    $"reason: {HttpRequestResponse.ResponseReason}")));
         }
     }
 }

--- a/src/main/WebsocketClientLite/Service/HandshakeHandler.cs
+++ b/src/main/WebsocketClientLite/Service/HandshakeHandler.cs
@@ -43,9 +43,9 @@ internal class HandshakeHandler(
         .Catch<
             (HandshakeStateKind handshakeState, WebsocketClientLiteException? ex),
             TimeoutException>(
-                tx => Observable.Return(
+                tx => Observable.Return<(HandshakeStateKind, WebsocketClientLiteException?)>(
                     (HandshakeStateKind.HandshakeTimedOut,
-                    new WebsocketClientLiteException("Handshake times out.", tx) ?? null)
+                    new WebsocketClientLiteException("Handshake timed out.", tx))
                 )
             );
 

--- a/src/main/WebsocketClientLite/Service/HandshakeHandler.cs
+++ b/src/main/WebsocketClientLite/Service/HandshakeHandler.cs
@@ -15,6 +15,12 @@ internal class HandshakeHandler(
     TcpConnectionService tcpConnectionService,
     Action<ConnectionStatus, Exception?> connectionStatusAction)
 {
+    /// <summary>
+    /// Subprotocols the server accepted (intersection with the ones offered),
+    /// available after a successful handshake.
+    /// </summary>
+    internal IEnumerable<string>? NegotiatedSubprotocols { get; private set; }
+
     internal IObservable<(HandshakeStateKind handshakeState, WebsocketClientLiteException? ex)> Handshake(
         Uri uri,
         WebsocketSenderHandler sender,
@@ -45,6 +51,8 @@ internal class HandshakeHandler(
             }
 
             await WaitForHandshake(handshakeParser).ConfigureAwait(false);
+
+            NegotiatedSubprotocols = handshakeParser.SubprotocolAcceptedNames;
 
             obs.OnCompleted();
         })

--- a/src/main/WebsocketClientLite/Service/HandshakeHandler.cs
+++ b/src/main/WebsocketClientLite/Service/HandshakeHandler.cs
@@ -34,7 +34,16 @@ internal class HandshakeHandler(
                 parserDelegate,
                 connectionStatusAction);
 
-            await SendHandshake(uri, sender, ct, origin, headers, subprotocols).ConfigureAwait(false);
+            var sendResult = await SendHandshake(uri, sender, ct, origin, headers, subprotocols).ConfigureAwait(false);
+
+            if (sendResult.handshakeState is HandshakeStateKind.HandshakeSendFailed)
+            {
+                // No point waiting for a response to a request that never went out.
+                obs.OnNext(sendResult);
+                obs.OnCompleted();
+                return;
+            }
+
             await WaitForHandshake(handshakeParser).ConfigureAwait(false);
 
             obs.OnCompleted();

--- a/src/main/WebsocketClientLite/Service/TcpConnectionService.cs
+++ b/src/main/WebsocketClientLite/Service/TcpConnectionService.cs
@@ -73,29 +73,51 @@ internal class TcpConnectionService(
         _stream = await GetTcpStream(uri, tcpClient, x509CertificateCollection, tlsProtocolType).ConfigureAwait(false);
     }
 
+    // Reusable buffer for the small fixed-size frame-header reads (first two
+    // header bytes, 2/8-byte extended length, 4-byte mask key). Reads on a
+    // connection are strictly sequential (single reader loop), so one scratch
+    // per connection is safe.
+    private readonly byte[] _headerScratch = new byte[8];
+
     internal ValueTask<byte[]?> ReadBytesFromStream(ulong size, CancellationToken ct) =>
         ReadByteArrayFromStream(size, ct);
 
     internal async ValueTask<byte[]?> ReadByteArrayFromStream(ulong size, CancellationToken ct)
+    {
+        // We cannot allocate arrays larger than int.MaxValue
+        int requested = checked((int)Math.Min((ulong)int.MaxValue, size));
+        var buffer = new byte[requested];
+
+        return await TryFillAsync(buffer, requested, ct).ConfigureAwait(false) ? buffer : null;
+    }
+
+    /// <summary>
+    /// Reads exactly <paramref name="count"/> (at most 8) bytes into the shared
+    /// per-connection scratch buffer, avoiding a small allocation per header
+    /// field. The returned array is only valid until the next read, and only the
+    /// first <paramref name="count"/> bytes are meaningful — callers must consume
+    /// it immediately (the frame parser does).
+    /// </summary>
+    internal async ValueTask<byte[]?> ReadHeaderBytesAsync(int count, CancellationToken ct) =>
+        await TryFillAsync(_headerScratch, count, ct).ConfigureAwait(false) ? _headerScratch : null;
+
+    private async ValueTask<bool> TryFillAsync(byte[] buffer, int count, CancellationToken ct)
     {
         if (_stream is null || !_stream.CanRead)
         {
             throw new WebsocketClientLiteException("Stream not ready or not connected.");
         }
 
-        // We cannot allocate arrays larger than int.MaxValue
-        int requested = checked((int)Math.Min((ulong)int.MaxValue, size));
-        var buffer = new byte[requested];
         int totalRead = 0;
 
         try
         {
-            while (totalRead < requested)
+            while (totalRead < count)
             {
 #if NETSTANDARD2_0
-                int read = await _stream.ReadAsync(buffer, totalRead, requested - totalRead, ct).ConfigureAwait(false);
+                int read = await _stream.ReadAsync(buffer, totalRead, count - totalRead, ct).ConfigureAwait(false);
 #else
-                int read = await _stream.ReadAsync(buffer.AsMemory(totalRead, requested - totalRead), ct).ConfigureAwait(false);
+                int read = await _stream.ReadAsync(buffer.AsMemory(totalRead, count - totalRead), ct).ConfigureAwait(false);
 #endif
                 if (read == 0)
                 {
@@ -109,7 +131,7 @@ internal class TcpConnectionService(
         catch (OperationCanceledException)
         {
             // Align with prior behavior (readOneByteFunc returned -1 on cancel)
-            return null;
+            return false;
         }
         catch (ObjectDisposedException)
         {
@@ -117,10 +139,10 @@ internal class TcpConnectionService(
             // cancellation: signal "no data" rather than returning a partially
             // filled/zeroed buffer that would be misread as a valid frame.
             Debug.WriteLine("Ignoring Object Disposed Exception - This is an expected exception");
-            return null;
+            return false;
         }
 
-        return buffer;
+        return true;
     }
 
     private async Task ConnectTcpClient(

--- a/src/main/WebsocketClientLite/Service/TcpConnectionService.cs
+++ b/src/main/WebsocketClientLite/Service/TcpConnectionService.cs
@@ -33,7 +33,8 @@ internal class TcpConnectionService(
     // explicit limit" (bounded only by the int.MaxValue array-size limit).
     internal int MaxFrameSize { get; } = maxFrameSize <= 0 ? int.MaxValue : maxFrameSize;
 
-    internal Stream ConnectionStream => _stream ?? throw new ArgumentNullException("Stream cannot be null");
+    internal Stream ConnectionStream => _stream
+        ?? throw new InvalidOperationException("Connection stream is not available. The TCP connection has not been established (or has been disposed).");
 
     // Serializes writes to the connection stream. Neither SslStream nor
     // NetworkStream supports concurrent writes, and the client may write from

--- a/src/main/WebsocketClientLite/Service/WebsocketConnectionHandler.cs
+++ b/src/main/WebsocketClientLite/Service/WebsocketConnectionHandler.cs
@@ -43,7 +43,7 @@ internal class WebsocketConnectionHandler : IDisposable
                 Uri uri,
                 X509CertificateCollection? x509CertificateCollection,
                 SslProtocols tlsProtocolType,
-                Action<ISender> setSenderAction,
+                Action<ISender, IEnumerable<string>?> setSenderAction,
                 CancellationToken ct,
                 bool hasClientPing,
                 TimeSpan clientPingTimeSpan,
@@ -89,7 +89,7 @@ internal class WebsocketConnectionHandler : IDisposable
             throw new WebsocketClientLiteException($"Handshake failed due to unknown error: {handshakeState}");
         }
 
-        setSenderAction(sender);
+        setSenderAction(sender, handshakeHandler.NegotiatedSubprotocols);
 
         if (hasClientPing)
         {

--- a/src/main/WebsocketClientLite/Service/WebsocketConnectionHandler.cs
+++ b/src/main/WebsocketClientLite/Service/WebsocketConnectionHandler.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Reactive;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Security.Cryptography.X509Certificates;
@@ -107,20 +109,56 @@ internal class WebsocketConnectionHandler : IDisposable
 
         _connectionStatusAction(ConnectionStatus.WebsocketConnected, null);
 
+        // The close handshake must run exactly once, whichever teardown path
+        // fires first: completion/error (via FinallyAsync) or the subscriber
+        // disposing the subscription (via the Disposable below, which previously
+        // sent no close frame at all).
+        int closeHandshakeStarted = 0;
+
+        async Task CloseOnceAsync()
+        {
+            if (Interlocked.Exchange(ref closeHandshakeStarted, 1) == 0)
+            {
+                await DisconnectWebsocket(sender).ConfigureAwait(false);
+            }
+        }
+
         return Observable.Create<IDataframe?>(dataframeObserver =>
-            // DataframeObservable now emits every message from a single
+        {
+            // DataframeObservable emits every message from a single
             // subscription, so no .Repeat() (and its per-message re-subscription)
             // is needed.
-            _websocketParserHandler.DataframeObservable()
+            var subscription = _websocketParserHandler.DataframeObservable()
                 .SelectMany(async dataframe =>
                     // Process control frames and return data frames
                     await IncomingControlFrameHandler(dataframe, dataframeObserver, cancellationToken).ConfigureAwait(false))
                 .Where(dataframe => dataframe is not null)
-                .Subscribe(dataframeObserver))
-        .FinallyAsync(async () =>
-        {
-            await DisconnectWebsocket(sender).ConfigureAwait(false);
-        });
+                .Subscribe(dataframeObserver);
+
+            return new CompositeDisposable(
+                subscription,
+                Disposable.Create(() =>
+                {
+                    // Unsubscribe path: best-effort close handshake, bounded so
+                    // disposal cannot hang. Task.Run avoids deadlocking callers
+                    // that dispose from a synchronization context (e.g. UI).
+                    try
+                    {
+                        var closeTask = Task.Run(CloseOnceAsync);
+                        if (!closeTask.Wait(TimeSpan.FromSeconds(3)))
+                        {
+                            _ = closeTask.ContinueWith(
+                                t => _ = t.Exception,
+                                TaskScheduler.Default);
+                        }
+                    }
+                    catch
+                    {
+                        // The connection is going away regardless.
+                    }
+                }));
+        })
+        .FinallyAsync(CloseOnceAsync);
 
         IObservable<Unit> SendClientPing(string? message) =>
             Observable.Interval(clientPingTimeSpan)
@@ -194,7 +232,10 @@ internal class WebsocketConnectionHandler : IDisposable
         }
         catch (Exception ex)
         {
-            throw new WebsocketClientLiteException("Unable to disconnect gracefully", ex);
+            // Best effort: the close frame is a courtesy. Failing to deliver it
+            // (dead stream, timeout) must not mask the error that triggered the
+            // teardown — especially now that send failures throw.
+            Debug.WriteLine($"Close handshake could not be delivered: {ex.Message}");
         }
         finally
         {

--- a/src/main/WebsocketClientLite/Service/WebsocketConnectionHandler.cs
+++ b/src/main/WebsocketClientLite/Service/WebsocketConnectionHandler.cs
@@ -5,7 +5,6 @@ using System.Reactive;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
-using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Security.Cryptography.X509Certificates;
@@ -25,6 +24,7 @@ internal class WebsocketConnectionHandler : IDisposable
     private readonly Func<Stream, Action<ConnectionStatus, Exception?>, WebsocketSenderHandler> _createWebsocketSenderFunc;
 
     private IDisposable? _clientPingDisposable;
+    private Func<Task>? _closeHandshakeOnce;
 
     internal WebsocketConnectionHandler(
         TcpConnectionService tcpConnectionService,
@@ -107,12 +107,12 @@ internal class WebsocketConnectionHandler : IDisposable
                 () => { });
         }
 
-        _connectionStatusAction(ConnectionStatus.WebsocketConnected, null);
-
         // The close handshake must run exactly once, whichever teardown path
-        // fires first: completion/error (via FinallyAsync) or the subscriber
-        // disposing the subscription (via the Disposable below, which previously
-        // sent no close frame at all).
+        // fires first: completion/error (via FinallyAsync below) or disposal
+        // (via Dispose(), reached on unsubscribe through ws.Dispose()). The hook
+        // is registered BEFORE WebsocketConnected is emitted so even a subscriber
+        // that disposes immediately upon "connected" — possibly before the inner
+        // pipeline subscription exists — still triggers the close handshake.
         int closeHandshakeStarted = 0;
 
         async Task CloseOnceAsync()
@@ -123,41 +123,20 @@ internal class WebsocketConnectionHandler : IDisposable
             }
         }
 
+        _closeHandshakeOnce = CloseOnceAsync;
+
+        _connectionStatusAction(ConnectionStatus.WebsocketConnected, null);
+
         return Observable.Create<IDataframe?>(dataframeObserver =>
-        {
             // DataframeObservable emits every message from a single
             // subscription, so no .Repeat() (and its per-message re-subscription)
             // is needed.
-            var subscription = _websocketParserHandler.DataframeObservable()
+            _websocketParserHandler.DataframeObservable()
                 .SelectMany(async dataframe =>
                     // Process control frames and return data frames
                     await IncomingControlFrameHandler(dataframe, dataframeObserver, cancellationToken).ConfigureAwait(false))
                 .Where(dataframe => dataframe is not null)
-                .Subscribe(dataframeObserver);
-
-            return new CompositeDisposable(
-                subscription,
-                Disposable.Create(() =>
-                {
-                    // Unsubscribe path: best-effort close handshake, bounded so
-                    // disposal cannot hang. Task.Run avoids deadlocking callers
-                    // that dispose from a synchronization context (e.g. UI).
-                    try
-                    {
-                        var closeTask = Task.Run(CloseOnceAsync);
-                        if (!closeTask.Wait(TimeSpan.FromSeconds(3)))
-                        {
-                            _ = closeTask.ContinueWith(
-                                t => _ = t.Exception,
-                                TaskScheduler.Default);
-                        }
-                    }
-                    catch
-                    {
-                        // The connection is going away regardless.
-                    }
-                }));
-        })
+                .Subscribe(dataframeObserver))
         .FinallyAsync(CloseOnceAsync);
 
         IObservable<Unit> SendClientPing(string? message) =>
@@ -245,7 +224,33 @@ internal class WebsocketConnectionHandler : IDisposable
 
     public void Dispose()
     {
+        // Stop the ping timer before saying goodbye.
         _clientPingDisposable?.Dispose();
+
+        // Unsubscribe path: ws.Dispose() (the outer Finally) is the one teardown
+        // hook guaranteed to run no matter how early the subscriber disposes, so
+        // the best-effort close handshake lives here. The stream is still alive —
+        // TcpConnectionService is disposed below, after the close frame goes out.
+        // Bounded so disposal cannot hang; Task.Run avoids deadlocking callers
+        // disposing from a synchronization context (e.g. UI). No-op when the
+        // close already ran via the completion/error path or never connected.
+        var closeOnce = Interlocked.Exchange(ref _closeHandshakeOnce, null);
+        if (closeOnce is not null)
+        {
+            try
+            {
+                var closeTask = Task.Run(closeOnce);
+                if (!closeTask.Wait(TimeSpan.FromSeconds(3)))
+                {
+                    _ = closeTask.ContinueWith(t => _ = t.Exception, TaskScheduler.Default);
+                }
+            }
+            catch
+            {
+                // Best effort — the connection is going away regardless.
+            }
+        }
+
         _websocketParserHandler?.Dispose();
         _tcpConnectionService?.Dispose();
     }

--- a/src/main/WebsocketClientLite/Service/WebsocketParserHandler.cs
+++ b/src/main/WebsocketClientLite/Service/WebsocketParserHandler.cs
@@ -48,6 +48,13 @@ internal class WebsocketParserHandler : IDisposable
                     }
 
                     obs.OnNext(dataframe);
+
+                    // After a Close frame the server will tear down the TCP
+                    // connection; stop reading instead of running into EOF.
+                    if (dataframe.Opcode is OpcodeKind.Close)
+                    {
+                        break;
+                    }
                 }
 
                 obs.OnCompleted();
@@ -100,8 +107,15 @@ internal class WebsocketParserHandler : IDisposable
             }
             else
             {
-                // Interleaved control frame: hand it downstream and keep reassembling.
+                // Interleaved control frame: hand it downstream.
                 obs.OnNext(next);
+
+                // A Close aborts the message — it can never complete, and the
+                // connection is about to go away.
+                if (next.Opcode is OpcodeKind.Close)
+                {
+                    return null;
+                }
             }
         }
 

--- a/src/main/WebsocketClientLite/Service/WebsocketSenderHandler.cs
+++ b/src/main/WebsocketClientLite/Service/WebsocketSenderHandler.cs
@@ -50,9 +50,9 @@ internal class WebsocketSenderHandler : ISender
         }
         catch (Exception ex)
         {
-            _connectionStatusAction(
-                ConnectionStatus.Aborted,
-                new WebsocketClientLiteException("Unable to complete handshake", ex));
+            // Propagate: HandshakeHandler turns this into HandshakeSendFailed and
+            // the connect path fails with it (no side-channel Abort needed).
+            throw new WebsocketClientLiteException("Unable to send websocket handshake.", ex);
         }
     }
 
@@ -159,9 +159,9 @@ internal class WebsocketSenderHandler : ISender
             }
             catch (Exception ex)
             {
-                _connectionStatusAction(
-                    ConnectionStatus.SendError,
-                    new WebsocketClientLiteException("Websocket send error occured.", ex));
+                var sendError = new WebsocketClientLiteException("Websocket send error occured.", ex);
+                _connectionStatusAction(ConnectionStatus.SendError, sendError);
+                throw sendError;
             }
 
             return;
@@ -411,9 +411,11 @@ internal class WebsocketSenderHandler : ISender
         }
         catch (Exception ex)
         {
-            _connectionStatusAction(
-                ConnectionStatus.SendError, 
-                new WebsocketClientLiteException("Websocket send error occured.", ex));
+            // Report through the status channel AND throw: callers awaiting a
+            // Send* method must observe the failure rather than a silent success.
+            var sendError = new WebsocketClientLiteException("Websocket send error occured.", ex);
+            _connectionStatusAction(ConnectionStatus.SendError, sendError);
+            throw sendError;
         }
     }
 }

--- a/src/main/WebsocketClientLite/WebsocketClientLite.csproj
+++ b/src/main/WebsocketClientLite/WebsocketClientLite.csproj
@@ -44,18 +44,12 @@ Easily and effectively observe incoming message using Reactive Extensions (Rx)</
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="bin\Release\netstandard2.0\I*.dll">
-      <PackagePath>lib\netstandard2.0\</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-
-    <Content Include="bin\Release\netstandard2.1\I*.dll">
-      <PackagePath>lib\netstandard2.1\</PackagePath>
-      <Pack>true</Pack>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
+    <!--
+      The interface assembly is delivered via the IWebsocketClientLite package
+      dependency generated from this ProjectReference. Do not also bundle the
+      DLL into lib/ — shipping it twice causes duplicate-assembly/type-conflict
+      issues for consumers.
+    -->
     <ProjectReference Include="..\..\interface\IWebsocketClientLite\IWebsocketClientLite.csproj" />
   </ItemGroup>
 

--- a/src/main/WebsocketClientLite/WebsocketClientLite.csproj
+++ b/src/main/WebsocketClientLite/WebsocketClientLite.csproj
@@ -8,18 +8,18 @@
     <LangVersion>14.0</LangVersion>
     <PackageIcon>images\1iveowl-logo.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>9.0.0</Version>
+    <Version>9.0.1</Version>
     <Authors>Jasper Hedegaard Bojsen</Authors>
     <Copyright>1iveowl Development 2025</Copyright>
     <PackageProjectUrl>https://github.com/1iveowl/WebsocketClientLite.PCL</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/1iveowl/WebsocketClientLite.PCL</RepositoryUrl>
-    <AssemblyVersion>9.0.0</AssemblyVersion>
-    <FileVersion>9.0.0</FileVersion>
+    <AssemblyVersion>9.0.1</AssemblyVersion>
+    <FileVersion>9.0.1</FileVersion>
     <Description>A simple and light WebSocket client.
 Can be set to ignore SSL/TLS server certificate issues (use with care!).
 Easily and effectively observe incoming message using Reactive Extensions (Rx)</Description>
-    <PackageReleaseNotes>v9.0.0: Subprotocols are now actually sent in the handshake; close status codes are sent big-endian (RFC 6455); ExcludeZeroApplicationDataInPong is now honored; the CancellationToken passed to WebsocketConnectObservable is now forwarded. More robust error handling and resource cleanup. Breaking: ClientWebSocketRx is now a class (was a record) and its TcpClient property is nullable. See README for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v9.0.1: Unsubscribing now sends the RFC 6455 close handshake; failed handshakes fail fast with the server's status code instead of timing out; send failures now throw at the await site (in addition to the SendError status); the final Disconnected status is delivered; new NegotiatedSubprotocols property; NuGet package no longer double-ships the interface assembly; reconnect requires leaving TcpClient unset (see README). See README for details.</PackageReleaseNotes>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>

--- a/src/main/WebsocketClientLiteTest/DataframeTests.cs
+++ b/src/main/WebsocketClientLiteTest/DataframeTests.cs
@@ -1,0 +1,41 @@
+using System.Text;
+using IWebsocketClientLite;
+using WebsocketClientLite.Model;
+using Xunit;
+
+namespace WebsocketClientLiteTest;
+
+public class DataframeTests
+{
+    [Fact]
+    public void Message_AfterWithClone_ReflectsNewPayload()
+    {
+        var first = new Dataframe
+        {
+            Opcode = OpcodeKind.Text,
+            Payload = Encoding.UTF8.GetBytes("abc"),
+        };
+
+        // Read Message BEFORE cloning — with a cached field this would poison the
+        // clone with the stale "abc" value.
+        Assert.Equal("abc", first.Message);
+
+        var merged = first with { Payload = Encoding.UTF8.GetBytes("abcdefghi") };
+
+        Assert.Equal("abcdefghi", merged.Message);
+        Assert.Equal("abc", first.Message); // original unaffected
+    }
+
+    [Fact]
+    public void Message_NonTextOpcode_IsNull()
+    {
+        var binary = new Dataframe
+        {
+            Opcode = OpcodeKind.Binary,
+            Payload = new byte[] { 1, 2, 3 },
+        };
+
+        Assert.Null(binary.Message);
+        Assert.Equal(new byte[] { 1, 2, 3 }, binary.Binary);
+    }
+}

--- a/src/main/WebsocketClientLiteTest/HandshakeParserTests.cs
+++ b/src/main/WebsocketClientLiteTest/HandshakeParserTests.cs
@@ -13,15 +13,19 @@ namespace WebsocketClientLiteTest;
 
 public class HandshakeParserTests
 {
-    private static (HandshakeParser parser, List<ConnectionStatus> statuses) Create()
+    private static (
+        HandshakeParser parser,
+        List<ConnectionStatus> statuses,
+        List<(HandshakeStateKind state, WebsocketClientLiteException? ex)> states) Create()
     {
         var statuses = new List<ConnectionStatus>();
+        var states = new List<(HandshakeStateKind state, WebsocketClientLiteException? ex)>();
         var observer = Observer.Create<(HandshakeStateKind state, WebsocketClientLiteException? ex)>(
-            _ => { }, _ => { }, () => { });
+            states.Add, _ => { }, () => { });
         var parserDelegate = new HandshakeParserDelegate(observer);
         var parserHandler = new HttpCombinedParser(parserDelegate);
         var parser = new HandshakeParser(parserHandler, parserDelegate, (status, _) => statuses.Add(status));
-        return (parser, statuses);
+        return (parser, statuses, states);
     }
 
     private static byte[] Response(params string[] headerLines)
@@ -36,9 +40,9 @@ public class HandshakeParserTests
     }
 
     [Fact]
-    public void Parse_SwitchingProtocols_ReturnsTrueWithoutAbort()
+    public void Parse_SwitchingProtocols_ReportsSuccess()
     {
-        var (parser, statuses) = Create();
+        var (parser, statuses, states) = Create();
 
         var done = parser.Parse(Response(
             "HTTP/1.1 101 Switching Protocols",
@@ -48,25 +52,31 @@ public class HandshakeParserTests
 
         Assert.True(done);
         Assert.DoesNotContain(ConnectionStatus.Aborted, statuses);
+        Assert.Contains(states, s => s.state == HandshakeStateKind.HandshakeCompletedSuccessfully);
     }
 
     [Fact]
-    public void Parse_NonSwitchingProtocols_AbortsConnection()
+    public void Parse_NonSwitchingProtocols_CompletesWithHandshakeFailed()
     {
-        var (parser, statuses) = Create();
+        var (parser, _, states) = Create();
 
         var done = parser.Parse(Response(
             "HTTP/1.1 404 Not Found",
             "Content-Length: 0"), null);
 
-        Assert.False(done);
-        Assert.Contains(ConnectionStatus.Aborted, statuses);
+        // The HTTP response is complete, so parsing is done — and the outcome is
+        // a failed handshake carrying the server's status code, not success.
+        Assert.True(done);
+        var failed = Assert.Single(states);
+        Assert.Equal(HandshakeStateKind.HandshakeFailed, failed.state);
+        Assert.NotNull(failed.ex);
+        Assert.Contains("404", failed.ex!.Message);
     }
 
     [Fact]
     public void Parse_AcceptedSubprotocol_DoesNotAbort()
     {
-        var (parser, statuses) = Create();
+        var (parser, statuses, states) = Create();
 
         var done = parser.Parse(Response(
             "HTTP/1.1 101 Switching Protocols",
@@ -76,12 +86,13 @@ public class HandshakeParserTests
 
         Assert.True(done);
         Assert.DoesNotContain(ConnectionStatus.Aborted, statuses);
+        Assert.Contains(states, s => s.state == HandshakeStateKind.HandshakeCompletedSuccessfully);
     }
 
     [Fact]
     public void Parse_UnknownSubprotocol_AbortsConnection()
     {
-        var (parser, statuses) = Create();
+        var (parser, statuses, _) = Create();
 
         parser.Parse(Response(
             "HTTP/1.1 101 Switching Protocols",

--- a/src/main/WebsocketClientLiteTest/IntegrationTests.cs
+++ b/src/main/WebsocketClientLiteTest/IntegrationTests.cs
@@ -156,6 +156,34 @@ public class IntegrationTests
     }
 
     [Fact]
+    public async Task DisposingClientBeforeSubscription_DoesNotThrowFromTeardown()
+    {
+        using var server = new LoopbackWebSocketServer();
+        server.Start(LoopbackWebSocketServer.EchoLoopAsync);
+
+        var client = new ClientWebSocketRx();
+        var connected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var subscription = client.WebsocketConnectWithStatusObservable(server.Uri)
+            .Subscribe(tuple =>
+            {
+                if (tuple.state == ConnectionStatus.WebsocketConnected)
+                {
+                    connected.TrySetResult();
+                }
+            },
+            _ => { });
+
+        await connected.Task.WaitAsync(Timeout);
+
+        // Dispose the client FIRST (disposing the IsConnected subject), then the
+        // subscription. Teardown's Finally reports IsConnected=false on the
+        // disposed subject — this must not throw.
+        client.Dispose();
+        subscription.Dispose();
+    }
+
+    [Fact]
     public async Task ClientPing_KeepsConnectionAlive_WhileSending()
     {
         using var server = new LoopbackWebSocketServer();

--- a/src/main/WebsocketClientLiteTest/IntegrationTests.cs
+++ b/src/main/WebsocketClientLiteTest/IntegrationTests.cs
@@ -156,6 +156,32 @@ public class IntegrationTests
     }
 
     [Fact]
+    public async Task NegotiatedSubprotocols_SurfaceTheServersChoice()
+    {
+        using var server = new LoopbackWebSocketServer();
+        server.Start(LoopbackWebSocketServer.EchoLoopAsync);
+
+        using var client = new ClientWebSocketRx { Subprotocols = new[] { "chat", "superchat" } };
+        var connected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var subscription = client.WebsocketConnectWithStatusObservable(server.Uri)
+            .Subscribe(tuple =>
+            {
+                if (tuple.state == ConnectionStatus.WebsocketConnected)
+                {
+                    connected.TrySetResult();
+                }
+            },
+            _ => { });
+
+        await connected.Task.WaitAsync(Timeout);
+
+        // The loopback server echoes the first offered subprotocol ("chat").
+        Assert.NotNull(client.NegotiatedSubprotocols);
+        Assert.Contains("chat", client.NegotiatedSubprotocols!);
+    }
+
+    [Fact]
     public async Task Non101HandshakeResponse_FailsFast_WithStatusCode()
     {
         using var server = new LoopbackWebSocketServer();

--- a/src/main/WebsocketClientLiteTest/IntegrationTests.cs
+++ b/src/main/WebsocketClientLiteTest/IntegrationTests.cs
@@ -156,6 +156,25 @@ public class IntegrationTests
     }
 
     [Fact]
+    public async Task Non101HandshakeResponse_FailsFast_WithStatusCode()
+    {
+        using var server = new LoopbackWebSocketServer();
+        server.StartWithRawHandshakeResponse("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n");
+
+        using var client = new ClientWebSocketRx();
+        var errored = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Generous handshake timeout: the failure must come from the parsed 404,
+        // not from the timeout elapsing.
+        using var subscription = client.WebsocketConnectWithStatusObservable(
+                server.Uri, handshaketimeout: TimeSpan.FromSeconds(30))
+            .Subscribe(_ => { }, ex => errored.TrySetResult(ex));
+
+        var error = await errored.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Contains("404", error.Message);
+    }
+
+    [Fact]
     public async Task DisposingClientBeforeSubscription_DoesNotThrowFromTeardown()
     {
         using var server = new LoopbackWebSocketServer();

--- a/src/main/WebsocketClientLiteTest/IntegrationTests.cs
+++ b/src/main/WebsocketClientLiteTest/IntegrationTests.cs
@@ -156,6 +156,53 @@ public class IntegrationTests
     }
 
     [Fact]
+    public async Task DisposingSubscription_SendsCloseHandshakeToServer()
+    {
+        using var server = new LoopbackWebSocketServer();
+        var closeObserved = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        server.Start(async (stream, ct) =>
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                var frame = await LoopbackWebSocketServer.ReadFrameAsync(stream, ct);
+                if (frame is null)
+                {
+                    closeObserved.TrySetResult(false); // TCP closed with no Close frame
+                    return;
+                }
+
+                if (frame.Value.opcode == 0x8)
+                {
+                    closeObserved.TrySetResult(true);  // proper close handshake
+                    return;
+                }
+            }
+        });
+
+        using var client = new ClientWebSocketRx();
+        var connected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var subscription = client.WebsocketConnectWithStatusObservable(server.Uri)
+            .Subscribe(tuple =>
+            {
+                if (tuple.state == ConnectionStatus.WebsocketConnected)
+                {
+                    connected.TrySetResult();
+                }
+            },
+            _ => { });
+
+        await connected.Task.WaitAsync(Timeout);
+
+        // Unsubscribing is how users disconnect; the server must see a Close
+        // frame, not just a dropped TCP connection.
+        subscription.Dispose();
+
+        Assert.True(await closeObserved.Task.WaitAsync(Timeout));
+    }
+
+    [Fact]
     public async Task NegotiatedSubprotocols_SurfaceTheServersChoice()
     {
         using var server = new LoopbackWebSocketServer();

--- a/src/main/WebsocketClientLiteTest/LoopbackWebSocketServer.cs
+++ b/src/main/WebsocketClientLiteTest/LoopbackWebSocketServer.cs
@@ -51,6 +51,34 @@ internal sealed class LoopbackWebSocketServer : IDisposable
         });
     }
 
+    /// <summary>
+    /// Accept one client, read its handshake request, and reply with the given
+    /// raw HTTP response (e.g. a 404) instead of completing the upgrade. The
+    /// connection is then held open so the client's behavior is driven purely by
+    /// the response content rather than an abrupt EOF.
+    /// </summary>
+    public void StartWithRawHandshakeResponse(string rawHttpResponse)
+    {
+        _serverLoop = Task.Run(async () =>
+        {
+            try
+            {
+                using var tcp = await _listener.AcceptTcpClientAsync(_cts.Token).ConfigureAwait(false);
+                using var stream = tcp.GetStream();
+                await ReadRequestHeadersAsync(stream, _cts.Token).ConfigureAwait(false);
+
+                var bytes = Encoding.ASCII.GetBytes(rawHttpResponse);
+                await stream.WriteAsync(bytes.AsMemory(), _cts.Token).ConfigureAwait(false);
+                await stream.FlushAsync(_cts.Token).ConfigureAwait(false);
+
+                await Task.Delay(Timeout.Infinite, _cts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { /* shutting down */ }
+            catch (IOException) { /* client disconnected */ }
+            catch (ObjectDisposedException) { /* listener stopped */ }
+        });
+    }
+
     /// <summary>Echoes data frames, replies to pings with pongs, and mirrors close.</summary>
     public static async Task EchoLoopAsync(Stream stream, CancellationToken ct)
     {
@@ -174,7 +202,7 @@ internal sealed class LoopbackWebSocketServer : IDisposable
         return buffer;
     }
 
-    private static async Task PerformHandshakeAsync(Stream stream, CancellationToken ct)
+    private static async Task<string> ReadRequestHeadersAsync(Stream stream, CancellationToken ct)
     {
         var sb = new StringBuilder();
         var one = new byte[1];
@@ -188,7 +216,14 @@ internal sealed class LoopbackWebSocketServer : IDisposable
             sb.Append((char)one[0]);
         }
 
-        var key = ExtractHeader(sb.ToString(), "Sec-WebSocket-Key");
+        return sb.ToString();
+    }
+
+    private static async Task PerformHandshakeAsync(Stream stream, CancellationToken ct)
+    {
+        var request = await ReadRequestHeadersAsync(stream, ct).ConfigureAwait(false);
+
+        var key = ExtractHeader(request, "Sec-WebSocket-Key");
         var accept = Convert.ToBase64String(
             SHA1.HashData(Encoding.ASCII.GetBytes(key + WebSocketGuid)));
 

--- a/src/main/WebsocketClientLiteTest/LoopbackWebSocketServer.cs
+++ b/src/main/WebsocketClientLiteTest/LoopbackWebSocketServer.cs
@@ -223,7 +223,8 @@ internal sealed class LoopbackWebSocketServer : IDisposable
     {
         var request = await ReadRequestHeadersAsync(stream, ct).ConfigureAwait(false);
 
-        var key = ExtractHeader(request, "Sec-WebSocket-Key");
+        var key = TryExtractHeader(request, "Sec-WebSocket-Key")
+            ?? throw new IOException("Missing header: Sec-WebSocket-Key");
         var accept = Convert.ToBase64String(
             SHA1.HashData(Encoding.ASCII.GetBytes(key + WebSocketGuid)));
 
@@ -231,14 +232,24 @@ internal sealed class LoopbackWebSocketServer : IDisposable
             "HTTP/1.1 101 Switching Protocols\r\n" +
             "Upgrade: websocket\r\n" +
             "Connection: Upgrade\r\n" +
-            $"Sec-WebSocket-Accept: {accept}\r\n\r\n";
+            $"Sec-WebSocket-Accept: {accept}\r\n";
+
+        // Echo the first offered subprotocol, like a real server selecting one.
+        var offered = TryExtractHeader(request, "Sec-WebSocket-Protocol");
+        if (offered is not null)
+        {
+            var first = offered.Split(',')[0].Trim();
+            response += $"Sec-WebSocket-Protocol: {first}\r\n";
+        }
+
+        response += "\r\n";
 
         var bytes = Encoding.ASCII.GetBytes(response);
         await stream.WriteAsync(bytes.AsMemory(), ct).ConfigureAwait(false);
         await stream.FlushAsync(ct).ConfigureAwait(false);
     }
 
-    private static string ExtractHeader(string request, string name)
+    private static string? TryExtractHeader(string request, string name)
     {
         foreach (var line in request.Split("\r\n"))
         {
@@ -248,7 +259,7 @@ internal sealed class LoopbackWebSocketServer : IDisposable
                 return line.Substring(colon + 1).Trim();
             }
         }
-        throw new IOException($"Missing header: {name}");
+        return null;
     }
 
     public void Dispose()

--- a/src/main/WebsocketClientLiteTest/PayloadParsingTests.cs
+++ b/src/main/WebsocketClientLiteTest/PayloadParsingTests.cs
@@ -125,6 +125,48 @@ public class PayloadParsingTests
     }
 
     [Fact]
+    public async Task CloseFrame_StopsReading_AndCompletes()
+    {
+        // Complete text frame, then a Close frame, then trailing garbage that must
+        // never be parsed (the reader stops after Close instead of hitting EOF).
+        byte[] frames =
+        {
+            0x81, 0x02, (byte)'h', (byte)'i',
+            0x88, 0x02, 0x03, 0xE8,   // Close, status 1000
+            0xFF, 0xFF, 0xFF,         // garbage past the close
+        };
+
+        var fake = new FakeTcpConnectionService(frames);
+        using var parser = new WebsocketParserHandler(fake);
+
+        var emitted = await parser.DataframeObservable().ToList();
+
+        Assert.Equal(2, emitted.Count);
+        Assert.Equal("hi", emitted[0]!.Message);
+        Assert.Equal(OpcodeKind.Close, emitted[1]!.Opcode);
+    }
+
+    [Fact]
+    public async Task CloseFrame_DuringReassembly_AbortsFragmentedMessage()
+    {
+        // Text(FIN=0) starts a message; a Close arrives before any continuation.
+        byte[] frames =
+        {
+            0x01, 0x02, (byte)'a', (byte)'b', // first fragment, not final
+            0x88, 0x00,                        // Close, no payload
+        };
+
+        var fake = new FakeTcpConnectionService(frames);
+        using var parser = new WebsocketParserHandler(fake);
+
+        var emitted = await parser.DataframeObservable().ToList();
+
+        // Only the Close frame surfaces; the incomplete message is dropped.
+        var frame = Assert.Single(emitted);
+        Assert.Equal(OpcodeKind.Close, frame!.Opcode);
+    }
+
+    [Fact]
     public async Task Parse_BinaryFrame_ExposesBinaryNotMessage()
     {
         byte[] payload = { 10, 20, 30, 40 };

--- a/src/main/WebsocketClientLiteTest/SendFrameTests.cs
+++ b/src/main/WebsocketClientLiteTest/SendFrameTests.cs
@@ -52,6 +52,54 @@ public class SendFrameTests
     private static byte[] Unmask(byte[] payload, byte[] key) =>
         payload.Select((b, i) => (byte)(b ^ key[i % 4])).ToArray();
 
+    private static WebsocketSenderHandler CreateFailingSender(
+        List<ConnectionStatus> statuses,
+        bool excludeZeroApplicationDataInPong = false)
+    {
+        var connection = new FakeConnection(new MemoryStream());
+
+        Func<Stream, byte[], int, CancellationToken, Task> failingWriteFunc =
+            (s, bytes, count, ct) => throw new IOException("socket reset");
+
+        return new WebsocketSenderHandler(
+            connection, (status, ex) => statuses.Add(status), failingWriteFunc, excludeZeroApplicationDataInPong);
+    }
+
+    [Fact]
+    public async Task SendText_WriteFailure_ThrowsAndReportsSendError()
+    {
+        var statuses = new List<ConnectionStatus>();
+        var sender = CreateFailingSender(statuses);
+
+        var ex = await Assert.ThrowsAsync<WebsocketClientLite.CustomException.WebsocketClientLiteException>(
+            () => sender.SendText("hello"));
+
+        Assert.IsType<IOException>(ex.InnerException);     // original cause preserved
+        Assert.Contains(ConnectionStatus.SendError, statuses); // status channel still notified
+    }
+
+    [Fact]
+    public async Task SendPong_ZeroDataPath_WriteFailure_Throws()
+    {
+        var statuses = new List<ConnectionStatus>();
+        var sender = CreateFailingSender(statuses, excludeZeroApplicationDataInPong: true);
+
+        await Assert.ThrowsAsync<WebsocketClientLite.CustomException.WebsocketClientLiteException>(
+            () => sender.SendPong(new Dataframe { Payload = Array.Empty<byte>() }, CancellationToken.None));
+
+        Assert.Contains(ConnectionStatus.SendError, statuses);
+    }
+
+    [Fact]
+    public async Task SendConnectHandShake_WriteFailure_Throws()
+    {
+        var statuses = new List<ConnectionStatus>();
+        var sender = CreateFailingSender(statuses);
+
+        await Assert.ThrowsAsync<WebsocketClientLite.CustomException.WebsocketClientLiteException>(
+            () => sender.SendConnectHandShake(new Uri("ws://example.com"), CancellationToken.None));
+    }
+
     [Fact]
     public async Task SendText_ProducesMaskedSingleTextFrame()
     {

--- a/src/main/WebsocketClientLiteTest/TcpConnectionServiceTests.cs
+++ b/src/main/WebsocketClientLiteTest/TcpConnectionServiceTests.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using WebsocketClientLite.Service;
+using Xunit;
+
+namespace WebsocketClientLiteTest;
+
+public class TcpConnectionServiceTests
+{
+    [Fact]
+    public void ConnectionStream_BeforeConnect_ThrowsInvalidOperation()
+    {
+        using var service = new TcpConnectionService(
+            () => false,
+            (o, c, ch, e) => true,
+            (client, uri) => Task.CompletedTask,
+            (status, ex) => { },
+            true,
+            new TcpClient());
+
+        // Invalid state (not connected yet) must surface as InvalidOperationException,
+        // not ArgumentNullException with the message in the paramName slot.
+        Assert.Throws<InvalidOperationException>(() => service.ConnectionStream);
+    }
+}

--- a/src/test/NETCore.Console.Test/Program.cs
+++ b/src/test/NETCore.Console.Test/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Net.Sockets;
 using System.Reactive.Linq;
 using System.Reactive.Disposables;
 using System.Security.Authentication;
@@ -59,12 +58,12 @@ private static async Task StartWebSocketAsyncWithRetry(
         _socketIOMessageFormattingFunc = msg => msg;
     }
 
-    TcpClient tcpClient = new() { LingerState = new LingerOption(true, 0) };
-
+    // NOTE: TcpClient is deliberately left unset. The Retry/Repeat pipeline below
+    // reconnects by re-subscribing, and each attempt needs a fresh socket — a
+    // supplied TcpClient can only ever serve the FIRST connection (its socket is
+    // closed on teardown and .NET sockets cannot be reconnected).
     var client = new ClientWebSocketRx
     {
-        TcpClient = tcpClient,
-        HasTransferSocketLifeCycleOwnership = false,
         // WARNING: this disables ALL TLS certificate validation and exposes the
         // connection to man-in-the-middle attacks. It is set here only for local
         // testing against self-signed/expired certs. NEVER enable it in production.


### PR DESCRIPTION
## Summary

9.0.1 patch release: fixes every finding from the post-9.0.0 code review, each as its own tested commit. The same branch has been pushed as `releases/9.0.1` to publish the packages; this PR brings the changes into `main`.

## Bug fixes
- **Unsubscribing now sends the RFC 6455 close handshake** — best-effort, exactly once, on every teardown path (previously the server only saw a dropped TCP connection). Bounded so disposal can't hang or deadlock a sync context.
- **Failed handshakes fail fast** — a non-101 response surfaces immediately as an error carrying the server's status code; previously the delegate reported an internal "success" for any complete HTTP response and the connect lingered until the 30s timeout. `SendHandshake`'s result is no longer discarded.
- **Send failures throw** — all `Send*` methods now throw `WebsocketClientLiteException` (original cause preserved) in addition to the `SendError` status; previously `await sender.SendText(...)` reported success even when the write failed.
- **Final `Disconnected` status is delivered** — the factories emitted Rx terminal events before the last `OnNext`, silently dropping it.
- **Close mid-fragmentation** cleanly aborts the message, and the read loop stops after a Close instead of reading into EOF.
- **Dispose-while-connected** no longer throws `ObjectDisposedException` from teardown.
- **Packaging**: the nupkg no longer bundles `IWebsocketClientLite.dll` into `lib/netstandard2.0/2.1` alongside the package dependency (duplicate-assembly/CS0433 hazard).
- **Reconnect**: the console sample no longer supplies a `TcpClient` (a supplied client can only serve the first connection); README + XML docs document the constraint.
- Cleanups: `ConnectionStream` throws `InvalidOperationException` (was a malformed `ArgumentNullException`), `Dataframe.Message` no longer caches (stale-on-`with` footgun), dead `?? null` removed.

## New
- **`ClientWebSocketRx.NegotiatedSubprotocols`** — exposes the subprotocol(s) the server accepted (previously computed but never surfaced).

## Performance
- Per-frame header reads (2-byte header, 2/8-byte extended length, 4-byte mask key) now reuse a single per-connection scratch buffer.

## Tests
- 63 → **75 tests**, line coverage ~74% → **77.5%**, all passing against every library build (netstandard2.0, 2.1, net8, net9, net10) in Debug and Release. New coverage: close-on-unsubscribe (server observes the Close frame), 404 fail-fast, negotiated subprotocols, dispose-order race, throwing sends, Close-during-reassembly, stale-cache regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
