### PR TITLE
v9.0.2: review fixes + close-on-unsubscribe race fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,14 @@ jobs:
           tag_name: ${{ steps.gitversion.outputs.AssemblySemVer }}
           release_name: Release ${{ steps.gitversion.outputs.AssemblySemVer }}
           body: |
-            WebsocketClientLite 9.0.1 – Highlights
+            WebsocketClientLite 9.0.2 – Highlights
+
+            - Fixes a race in the 9.0.1 close-on-unsubscribe behavior: disposing the
+              subscription immediately after WebsocketConnected could skip the close
+              handshake. The close hook is now registered before WebsocketConnected is
+              emitted and runs on every teardown path. Use 9.0.2 instead of 9.0.1.
+
+            Includes all 9.0.1 changes:
 
             Bug fixes
             - Unsubscribing from the connection observable now sends the RFC 6455 close

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,4 @@
-next-version: 9.0.1
+next-version: 9.0.2
 branches: {}
 ignore:
   sha: []

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ The library provides developers with additional flexibility, including the abili
 
 The library utilizes [ReactiveX](http://reactivex.io/) (aka Rx or Reactive Extensions). While this dependency introduces a small learning curve, it's worthwhile for the context.
 
+## New in Version 9.0.2
+
+Fixes a race in the 9.0.1 close-on-unsubscribe behavior: disposing the connection subscription immediately after `WebsocketConnected` could tear the connection down before the close-handshake hook was wired, skipping the close frame. The hook is now registered before `WebsocketConnected` is emitted and runs on every teardown path. Use 9.0.2 instead of 9.0.1.
+
 ## New in Version 9.0.1
 
 Version 9.0.1 is a correctness and robustness patch on top of 9.0.

--- a/src/interface/IWebsocketClientLite/IWebsocketClientLite.csproj
+++ b/src/interface/IWebsocketClientLite/IWebsocketClientLite.csproj
@@ -8,13 +8,13 @@
 	<LangVersion>14.0</LangVersion>
 	<PackageIcon>images\1iveowl-logo.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>9.0.1</Version>
+    <Version>9.0.2</Version>
     <Authors>Jasper Hedegaard Bojsen</Authors>
     <Copyright>1iveowl Development 2025</Copyright>
     <PackageProjectUrl>https://github.com/1iveowl/IWebsocketClientLite.PCL</PackageProjectUrl>
     <RepositoryUrl>https://github.com/1iveowl/WebsocketClientLite.PCL</RepositoryUrl>
-    <AssemblyVersion>9.0.1</AssemblyVersion>
-    <FileVersion>9.0.1</FileVersion>
+    <AssemblyVersion>9.0.2</AssemblyVersion>
+    <FileVersion>9.0.2</FileVersion>
     <Description>Interface for WebSocket Client Lite.</Description>
   </PropertyGroup>
 

--- a/src/main/WebsocketClientLite/WebsocketClientLite.csproj
+++ b/src/main/WebsocketClientLite/WebsocketClientLite.csproj
@@ -8,18 +8,18 @@
     <LangVersion>14.0</LangVersion>
     <PackageIcon>images\1iveowl-logo.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>9.0.1</Version>
+    <Version>9.0.2</Version>
     <Authors>Jasper Hedegaard Bojsen</Authors>
     <Copyright>1iveowl Development 2025</Copyright>
     <PackageProjectUrl>https://github.com/1iveowl/WebsocketClientLite.PCL</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/1iveowl/WebsocketClientLite.PCL</RepositoryUrl>
-    <AssemblyVersion>9.0.1</AssemblyVersion>
-    <FileVersion>9.0.1</FileVersion>
+    <AssemblyVersion>9.0.2</AssemblyVersion>
+    <FileVersion>9.0.2</FileVersion>
     <Description>A simple and light WebSocket client.
 Can be set to ignore SSL/TLS server certificate issues (use with care!).
 Easily and effectively observe incoming message using Reactive Extensions (Rx)</Description>
-    <PackageReleaseNotes>v9.0.1: Unsubscribing now sends the RFC 6455 close handshake; failed handshakes fail fast with the server's status code instead of timing out; send failures now throw at the await site (in addition to the SendError status); the final Disconnected status is delivered; new NegotiatedSubprotocols property; NuGet package no longer double-ships the interface assembly; reconnect requires leaving TcpClient unset (see README). See README for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v9.0.2: Fixes a race in the 9.0.1 close-on-unsubscribe feature where disposing the subscription immediately after WebsocketConnected could skip the close handshake. Includes all 9.0.1 changes: close handshake on unsubscribe; fail-fast handshake errors with the server's status code; send failures throw at the await site; final Disconnected status delivered; new NegotiatedSubprotocols property; NuGet packaging fix; reconnect requires leaving TcpClient unset. See README for details.</PackageReleaseNotes>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>


### PR DESCRIPTION
## Summary

Supersedes #91 (same commits plus two more): all 13 post-9.0.0 review fixes, **plus the close-on-unsubscribe race fix that CI caught on #91**, and the 9.0.2 version bump. The `releases/9.0.2` branch has been pushed, publishing the 9.0.2 packages with the race fix included (the published 9.0.1 binaries predate it).

## On top of #91
- **fix: close-on-unsubscribe race caught by CI** — the close-once hook was attached to the inner pipeline subscription, but `WebsocketConnected` fires before that subscription exists; disposing immediately upon "connected" skipped the close frame (reliably reproduced on CI runners). The hook is now registered before `WebsocketConnected` is emitted and runs from `Dispose()`, which the outer `Finally(ws.Dispose())` guarantees on every teardown path. Verified by stressing the integration test 15× plus the full cross-TFM sweep.
- **Bump to 9.0.2** (csproj ×2, GitVersion, README note, release-notes body).

## Carried over from #91 (see that PR for detail)
Close handshake on unsubscribe; fail-fast handshake errors with the server's status code; send failures throw at the await site; final `Disconnected` status delivered; Close mid-fragmentation aborts cleanly; dispose-while-connected guard; NuGet packaging fix (no double-shipped interface DLL); reconnect guidance (leave `TcpClient` unset); `NegotiatedSubprotocols` property; header-read scratch buffer; assorted cleanups. Tests 63 → 75, coverage ~77.5%, all TFMs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
