### PR TITLE
chore: justify intentional analyzer suppressions; reorder CT parameter

### DIFF
--- a/src/main/WebsocketClientLite/ClientWebSocketRx.cs
+++ b/src/main/WebsocketClientLite/ClientWebSocketRx.cs
@@ -268,7 +268,6 @@ public class ClientWebSocketRx : IWebSocketClientRx, IDisposable
                 X509CertCollection,
                 TlsProtocolType,
                 initSender,
-                ct,
                 hasClientPing,
                 clientPingInterval,
                 clientPingMessage,
@@ -276,6 +275,7 @@ public class ClientWebSocketRx : IWebSocketClientRx, IDisposable
                 Origin,
                 Headers,
                 Subprotocols,
+                ct,
                 cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/main/WebsocketClientLite/MessageWebSocketRx.cs
+++ b/src/main/WebsocketClientLite/MessageWebSocketRx.cs
@@ -178,14 +178,14 @@ public class MessageWebsocketRx(
                                                 X509CertCollection,
                                                 TlsProtocolType,
                                                 InitializeSender,
-                                                ct,
                                                 hasClientPing,
                                                 clientPingInterval,
                                                 clientPingMessage,
                                                 handshaketimeout,
                                                 Origin,
                                                 Headers,
-                                                Subprotocols).ConfigureAwait(false);
+                                                Subprotocols,
+                                                ct).ConfigureAwait(false);
 
         void InitializeSender(ISender sender, IEnumerable<string>? negotiatedSubprotocols)
         {

--- a/src/main/WebsocketClientLite/Service/HandshakeHandler.cs
+++ b/src/main/WebsocketClientLite/Service/HandshakeHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using HttpMachine;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -89,7 +90,11 @@ internal class HandshakeHandler(
         }
     }
 
-    private async Task<(HandshakeStateKind handshakeState, WebsocketClientLiteException? ex)> 
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types",
+        Justification = "Nothing is swallowed: the exception is converted into the HandshakeSendFailed result " +
+                        "state (with the original exception preserved) which the connect path observes and throws. " +
+                        "Any write-failure type must take this path, so the catch is intentionally broad.")]
+    private async Task<(HandshakeStateKind handshakeState, WebsocketClientLiteException? ex)>
         SendHandshake(
             Uri uri,
             WebsocketSenderHandler websocketSenderHandler,

--- a/src/main/WebsocketClientLite/Service/TcpConnectionService.cs
+++ b/src/main/WebsocketClientLite/Service/TcpConnectionService.cs
@@ -1,6 +1,7 @@
 ﻿using IWebsocketClientLite;
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Net.Security;
 using System.Net.Sockets;
@@ -145,6 +146,11 @@ internal class TcpConnectionService(
         return true;
     }
 
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
+        Justification = "Ownership is tracked, not lost: the created TcpClient is assigned to the captured " +
+                        "constructor parameter and _ownsCreatedTcpClient is set, so Dispose() always releases " +
+                        "it regardless of the lifecycle-ownership flag. The analyzer cannot follow ownership " +
+                        "through the captured parameter.")]
     private async Task ConnectTcpClient(
         Uri uri,
         TimeSpan timeout = default)

--- a/src/main/WebsocketClientLite/Service/WebsocketConnectionHandler.cs
+++ b/src/main/WebsocketClientLite/Service/WebsocketConnectionHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reactive;
 using System.Threading;
@@ -46,7 +47,6 @@ internal class WebsocketConnectionHandler : IDisposable
                 X509CertificateCollection? x509CertificateCollection,
                 SslProtocols tlsProtocolType,
                 Action<ISender, IEnumerable<string>?> setSenderAction,
-                CancellationToken ct,
                 bool hasClientPing,
                 TimeSpan clientPingTimeSpan,
                 string? clientPingMessage,
@@ -54,6 +54,7 @@ internal class WebsocketConnectionHandler : IDisposable
                 string? origin,
                 IDictionary<string, string>? headers,
                 IEnumerable<string>? subprotocols,
+                CancellationToken ct,
                 CancellationToken cancellationToken = default)
     {
         if (hasClientPing && clientPingTimeSpan == default)
@@ -200,6 +201,10 @@ internal class WebsocketConnectionHandler : IDisposable
         }
     }
 
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types",
+        Justification = "The close frame is a best-effort courtesy. Whatever the failure type (dead stream, " +
+                        "timeout, disposed socket), it must not mask the error that triggered the teardown — " +
+                        "send failures otherwise throw at the call site by design.")]
     internal async Task DisconnectWebsocket(
         WebsocketSenderHandler sender)
     {
@@ -222,6 +227,9 @@ internal class WebsocketConnectionHandler : IDisposable
         }
     }
 
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types",
+        Justification = "Dispose must never throw. The guarded block is the bounded best-effort close " +
+                        "handshake; any failure there is irrelevant because the connection is being torn down.")]
     public void Dispose()
     {
         // Stop the ping timer before saying goodbye.

--- a/src/main/WebsocketClientLite/Service/WebsocketParserHandler.cs
+++ b/src/main/WebsocketClientLite/Service/WebsocketParserHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using System.Threading;
@@ -25,6 +26,10 @@ internal class WebsocketParserHandler : IDisposable
     // element per (reassembled) message. The token is signaled when the
     // subscriber unsubscribes, so there is no per-message re-subscription and no
     // per-subscription CancellationTokenSource to allocate.
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types",
+        Justification = "Rx contract: any failure in the read loop must be routed to the observer via OnError, " +
+                        "not escape the async subscribe body. Catching specific types would let unanticipated " +
+                        "exceptions kill the process instead of erroring the subscription.")]
     internal IObservable<Dataframe?> DataframeObservable() =>
         Observable.Create<Dataframe?>(async (obs, token) =>
         {


### PR DESCRIPTION
## Summary

Maintenance only — no behavior change, no version bump. Brings every build to **zero warnings** without weakening any analyzer rules globally (`AnalysisMode` stays `AllEnabledByDefault`), so future real warnings stand out.

## Changes

**CA1031 (4 sites)** — `[SuppressMessage]` with written justifications where the broad catch *is* the design:
- `WebsocketParserHandler.DataframeObservable` — Rx contract: failures route to `OnError`, not out of the async subscribe body.
- `HandshakeHandler.SendHandshake` — failures become the `HandshakeSendFailed` result (exception preserved and later thrown by the connect path).
- `WebsocketConnectionHandler.DisconnectWebsocket` — best-effort close must not mask the error that triggered teardown.
- `WebsocketConnectionHandler.Dispose` — `Dispose` must never throw.

**CA2000 (1 site)** — `TcpConnectionService.ConnectTcpClient`: ownership of the fallback `TcpClient` is tracked via `_ownsCreatedTcpClient` and released in `Dispose()`; the analyzer can't follow ownership through the captured constructor parameter.

**CA1068 (1 site)** — fixed properly instead of suppressed: the subscription `CancellationToken` moved to the end of the internal `ConnectWebsocket` signature (both tokens last); both call sites updated.

## Verification
- Zero CA/CS warnings across all five target frameworks.
- Full cross-TFM test sweep (75 tests × netstandard2.0/2.1/net8/net9/net10) green, run twice consecutively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
